### PR TITLE
Ability to split a message if it's too big to send in one piece

### DIFF
--- a/api.go
+++ b/api.go
@@ -336,6 +336,28 @@ func (c *API) SendMessage(
 	return c.Send(ctx, cfg)
 }
 
+// SplitAndSendMessage splits original message if it's larger that maximum allowed Telegram message and sends splitted results
+func (c *API) SplitAndSendMessage(
+	ctx context.Context,
+	cfg MessageCfg) ([]*Message, error) {
+
+	chatID := cfg.ID
+	messageTexts := SplitMessageString(cfg.Text)
+	var err error
+	var sentMessageP *Message
+
+	var resultMessagesP []*Message
+	for text := range messageTexts {
+		sentMessageP, err = c.Send(ctx, NewMessagef(chatID, text))
+		if err != nil {
+			return resultMessagesP, err
+		}
+		resultMessagesP = append(resultMessagesP, sentMessageP)
+	}
+
+	return resultMessagesP, nil
+}
+
 // SendSticker sends message with sticker.
 func (c *API) SendSticker(
 	ctx context.Context,

--- a/constants.go
+++ b/constants.go
@@ -104,3 +104,8 @@ const (
 	LeftMemberStatus          = "left"
 	KickedMemberStatus        = "kicked"
 )
+
+// Telegram constants
+const (
+	MaximumMessageLength = 4096
+)

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"net/url"
 	"regexp"
+	"unicode"
 )
 
 var tokenRegex = regexp.MustCompile(`^[\d]{3,11}:[\w-]{35}$`)
@@ -12,6 +13,74 @@ var tokenRegex = regexp.MustCompile(`^[\d]{3,11}:[\w-]{35}$`)
 // Token format is like: 110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsawq
 func IsValidToken(token string) bool {
 	return tokenRegex.MatchString(token)
+}
+
+//SplitMessageString splits original message in case it's too big for telegram message and sends each piece of a split separately
+func SplitMessageString(message string) <-chan string {
+	out := make(chan string)
+	originalMessage := []rune(message)
+	originalMessageLength := len(originalMessage)
+
+	go func() {
+		previousChunkEnd, lastSuccessfulCheckpoint, curPosition := 0, 0, 0
+		usedBytes, newBytes := 0, 0
+
+		initializeChunk := func() bool {
+			for ; previousChunkEnd < originalMessageLength && unicode.IsSpace(originalMessage[previousChunkEnd]); previousChunkEnd++ {
+			}
+			if previousChunkEnd >= originalMessageLength {
+				return true
+			}
+
+			curPosition, lastSuccessfulCheckpoint = previousChunkEnd, previousChunkEnd
+			usedBytes, newBytes = 0, 0
+			return false
+		}
+
+		walkChars := func(checkFunc func(rune) bool) bool {
+			for ; curPosition < originalMessageLength && checkFunc(originalMessage[curPosition]); curPosition++ {
+				newBytes = usedBytes + len(string(originalMessage[curPosition]))
+				if newBytes > MaximumMessageLength {
+					return true
+				}
+				usedBytes = newBytes
+			}
+			return curPosition >= originalMessageLength
+		}
+
+		for curPosition < originalMessageLength {
+			if initializeChunk() {
+				break
+			}
+
+			for usedBytes <= MaximumMessageLength {
+				if walkChars(unicode.IsSpace) {
+					break
+				}
+				if walkChars(func(r rune) bool { return !unicode.IsSpace(r) }) {
+					break
+				}
+				lastSuccessfulCheckpoint = curPosition
+			}
+
+			if lastSuccessfulCheckpoint == previousChunkEnd {
+				out <- string(originalMessage[previousChunkEnd:curPosition])
+				previousChunkEnd = curPosition
+				continue
+			}
+
+			if curPosition >= originalMessageLength {
+				lastSuccessfulCheckpoint = curPosition
+			}
+
+			out <- string(originalMessage[previousChunkEnd:lastSuccessfulCheckpoint])
+
+			previousChunkEnd = lastSuccessfulCheckpoint
+		}
+		close(out)
+	}()
+
+	return out
 }
 
 // ========== Internal functions

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,11 +1,20 @@
 package telegram_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/bot-api/telegram"
 	"gopkg.in/stretchr/testify.v1/assert"
 )
+
+func getValuesFromChannel(in <-chan string) []string {
+	var result []string
+	for s := range in {
+		result = append(result, s)
+	}
+	return result
+}
 
 func TestIsValidToken(t *testing.T) {
 	testTable := []struct {
@@ -23,4 +32,148 @@ func TestIsValidToken(t *testing.T) {
 		t.Logf("test #%d", i)
 		assert.Equal(t, tt.result, telegram.IsValidToken(tt.token))
 	}
+}
+
+func TestSplittingMessageEndgeOnSpace(t *testing.T) {
+	var buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength-1; i++ {
+		buffer.WriteString("a")
+	}
+	firstPart := buffer.String()
+	buffer.WriteString("      ")
+	secondPart := "bbb ccc ddd"
+	buffer.WriteString(secondPart)
+
+	originalMessage := buffer.String()
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 2)
+	assert.Equal(t, messages[0], firstPart)
+	assert.Equal(t, messages[1], secondPart)
+}
+
+func TestSplittingMessageEndgeOnLetter(t *testing.T) {
+	var buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength-3; i++ {
+		buffer.WriteString("a")
+	}
+	firstPart := buffer.String()
+	buffer.WriteString(" ")
+	secondPart := "bbb ccc ddd"
+	buffer.WriteString(secondPart)
+
+	originalMessage := buffer.String()
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 2)
+	assert.Equal(t, messages[0], firstPart)
+	assert.Equal(t, messages[1], secondPart)
+}
+
+func TestSplittingMessageLongWordNoSpace(t *testing.T) {
+	var buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength; i++ {
+		buffer.WriteString("a")
+	}
+	firstPart := buffer.String()
+	secondPart := "bbb"
+
+	buffer.WriteString(secondPart)
+	originalMessage := buffer.String()
+
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 2)
+	assert.Equal(t, messages[0], firstPart)
+	assert.Equal(t, messages[1], secondPart)
+}
+
+func TestSplittingMessageLongWordNoSpace0(t *testing.T) {
+	var buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength; i++ {
+		buffer.WriteString("a")
+	}
+	firstPart := buffer.String()
+	secondPart := "a"
+
+	buffer.WriteString(secondPart)
+	originalMessage := buffer.String()
+
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 2)
+	assert.Equal(t, messages[0], firstPart)
+	assert.Equal(t, messages[1], secondPart)
+}
+
+func TestSplittingMessageLongWordNoSpace2(t *testing.T) {
+	var originalMessageBuffer, buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength/2; i++ {
+		buffer.WriteString("к")
+	}
+	firstPart := buffer.String()
+	originalMessageBuffer.WriteString(firstPart)
+	buffer.Reset()
+
+	for i := 0; i < telegram.MaximumMessageLength; i++ {
+		buffer.WriteString("a")
+	}
+	secondPart := buffer.String()
+	originalMessageBuffer.WriteString(secondPart)
+	buffer.Reset()
+
+	for i := 0; i < telegram.MaximumMessageLength/2; i++ {
+		buffer.WriteString("к")
+	}
+	thirdPart := buffer.String()
+	originalMessageBuffer.WriteString(thirdPart)
+
+	originalMessage := originalMessageBuffer.String()
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 3)
+	assert.Equal(t, messages[0], firstPart)
+	assert.Equal(t, messages[1], secondPart)
+	assert.Equal(t, messages[2], thirdPart)
+
+}
+
+func TestSplittingMessageLongWordNoSpace3(t *testing.T) {
+	var buffer bytes.Buffer
+
+	for i := 0; i < telegram.MaximumMessageLength-1; i++ {
+		buffer.WriteString("a")
+	}
+	firstPart := buffer.String()
+
+	buffer.WriteString("к")
+	secondPart := "к"
+
+	originalMessage := buffer.String()
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 2)
+	assert.Equal(t, messages[0], firstPart)
+	assert.Equal(t, messages[1], secondPart)
+
+}
+
+func TestSpacesInFron(t *testing.T) {
+	var buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength-1; i++ {
+		buffer.WriteString(" ")
+	}
+	firstPart := "aaaa"
+
+	buffer.WriteString(firstPart)
+	originalMessage := buffer.String()
+
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 1)
+	assert.Equal(t, messages[0], firstPart)
+}
+
+func TestSpacesOnly(t *testing.T) {
+	var buffer bytes.Buffer
+	for i := 0; i < telegram.MaximumMessageLength+1; i++ {
+		buffer.WriteString(" ")
+	}
+	originalMessage := buffer.String()
+
+	messages := getValuesFromChannel(telegram.SplitMessageString(originalMessage))
+	assert.Len(t, messages, 0)
 }


### PR DESCRIPTION
If a message is larger than 4096 bytes telegram API doesn't accept it. I added an api call that split big messages like that to smaller pieces and them send them one by one. Every time we try to split the text by whitespace symbols if it's possible. Otherwise we simply cut a word as soon as it's size is greater than allowed size.